### PR TITLE
Fixed rotate error on Android devices

### DIFF
--- a/Resources/js/views/PortalWindowView.js
+++ b/Resources/js/views/PortalWindowView.js
@@ -86,17 +86,12 @@ exports.close = function () {
     portletCollectionView.close();
 };
 
-exports.rotateView = function (orientation) {
-    portletCollectionView && portletCollectionView.rotate(orientation, notificationsView.currentState() === notificationsView.states['HIDDEN'] ? false : true);
-};
-
 function _drawUI (_isGuestLayout, _isPortalReachable) {
     Ti.API.debug('_drawUI() in PortalWindowView. _isGuestLayout: '+_isGuestLayout+', _isPortalReachable: '+_isPortalReachable);
     // This method should only be concerned with drawing the UI, not with any other logic. Leave that to the caller.
     
     if (getState() !== exports.states['INITIALIZED']) {
         exports.updateLayout(_isPortalReachable, _isGuestLayout);
-        exports.rotateView();
         return;
     }
     


### PR DESCRIPTION
Rotate function was being called but was previously deleted in commit 3fce4f6. Android devices were calling rotate function when pressing Home button in application.
